### PR TITLE
Update before_install.sh

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -5,7 +5,8 @@ echo 'Installing Pebble SDK and its Dependencies...'
 cd ~ 
 
 # Get the Pebble SDK and toolchain
-wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk2/${PEBBLE_SDK}.tar.gz -O PebbleSDK.tar.gz
+PEBBLE_SDK_VER=${PEBBLE_SDK#PebbleSDK-}
+wget https://sdk.getpebble.com/download/${PEBBLE_SDK_VER} -O PebbleSDK.tar.gz
 wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
 
 # Build the Pebble directory

--- a/before_install.sh
+++ b/before_install.sh
@@ -6,7 +6,7 @@ cd ~
 
 # Get the Pebble SDK and toolchain
 PEBBLE_SDK_VER=${PEBBLE_SDK#PebbleSDK-}
-wget https://sdk.getpebble.com/download/${PEBBLE_SDK_VER} -O PebbleSDK.tar.gz
+wget "https://sdk.getpebble.com/download/${PEBBLE_SDK_VER}?source=pbuild" -O PebbleSDK.tar.gz
 wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
 
 # Build the Pebble directory


### PR DESCRIPTION
Change to use new Pebble SDK download redirection servers

I ttested with my two personal GitHub hosted watch projects.  This is based on a change just submitted to CloudPebble by @matthewtole
