### PR TITLE
Update to work with Travis-CI container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: pebblec
-sudo: true
-before_script: ./before_install.sh
-script: ./build.sh
+sudo: false
+before_script: bash ./before_install.sh
+script: bash ./build.sh
+cache:
+  directories:
+    - $HOME/pebble-dev
+    - $HOME/.cache/pip
+addons:
+  apt:
+    packages:
+    - python2.7-dev
+    - python-pip
+    - python-virtualenv

--- a/before_install.sh
+++ b/before_install.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+set -e
 echo 'pBuild 1.0'
 echo 'Installing Pebble SDK and its Dependencies...'
 
@@ -6,37 +7,21 @@ cd ~
 
 # Get the Pebble SDK and toolchain
 PEBBLE_SDK_VER=${PEBBLE_SDK#PebbleSDK-}
-wget "https://sdk.getpebble.com/download/${PEBBLE_SDK_VER}?source=pbuild" -O PebbleSDK.tar.gz
-wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
+if [ ! -d $HOME/pebble-dev/${PEBBLE_SDK} ]; then
+  wget https://sdk.getpebble.com/download/${PEBBLE_SDK_VER} -O PebbleSDK-${PEBBLE_SDK_VER}.tar.gz
+  wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
+  # Build the Pebble directory
+  mkdir -p ~/pebble-dev
+  # Extract the SDK
+  tar zxf PebbleSDK-${PEBBLE_SDK_VER}.tar.gz -C ~/pebble-dev/
+  # Extract the toolchain
+  tar zxf arm-cs-tools-ubuntu-universal.tar.gz -C ~/pebble-dev/${PEBBLE_SDK}
 
-# Build the Pebble directory
-mkdir ~/pebble-dev
-
-cd ~/pebble-dev
-
-# Extract the SDK
-tar -zxf ~/PebbleSDK.tar.gz
-
-cd ~/pebble-dev/${PEBBLE_SDK}
-
-# Extract the toolchain
-tar -zxf ~/arm-cs-tools-ubuntu-universal.tar.gz
-
-# (Add the pebble tool to your path and reload your shell configuration) isn't used because it fails
-
-# Install pip and virtualenv
-sudo apt-get install python-pip python2.7-dev
-sudo pip install virtualenv
-
-# Install the Python library dependencies locally
-virtualenv --no-site-packages .env
-source .env/bin/activate
-pip install -r requirements.txt
-deactivate
-
-
-
-
-
-
+  # Install the Python library dependencies locally
+  cd ~/pebble-dev/${PEBBLE_SDK}
+  virtualenv --no-site-packages .env
+  source .env/bin/activate
+  pip install -r requirements.txt
+  deactivate
+fi
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
+#!/bin/bash
+set -e
 echo "Building Pebble project..."
-
 cd ~/build/${PEBBLE_PROJECT_PATH}
-
 # pebble build isn't used because it fails
-
 ~/pebble-dev/${PEBBLE_SDK}/bin/pebble build


### PR DESCRIPTION
This removes the need for sudo and lets builds start quicker
as they don't have to spin up a whole virtual machine. The
install of virtualenv is moved into the apt-get section of
.travis.yml and before_install.sh now only installs tools
if they aren't cached.

Tested with my resistor-time repo, verified to work on
first build and when tools are reloaded from cache.
