### PR TITLE
Create "ENABLE_ANALYTICS" file in pebble-dev

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -4,14 +4,15 @@ echo 'pBuild 1.0'
 echo 'Installing Pebble SDK and its Dependencies...'
 
 cd ~ 
+mkdir -p ~/pebble-dev
+touch ~/pebble-dev/ENABLE_ANALYTICS
 
 # Get the Pebble SDK and toolchain
 PEBBLE_SDK_VER=${PEBBLE_SDK#PebbleSDK-}
 if [ ! -d $HOME/pebble-dev/${PEBBLE_SDK} ]; then
   wget https://sdk.getpebble.com/download/${PEBBLE_SDK_VER} -O PebbleSDK-${PEBBLE_SDK_VER}.tar.gz
   wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
-  # Build the Pebble directory
-  mkdir -p ~/pebble-dev
+
   # Extract the SDK
   tar zxf PebbleSDK-${PEBBLE_SDK_VER}.tar.gz -C ~/pebble-dev/
   # Extract the toolchain


### PR DESCRIPTION
This fixes an issue with the 3.2 SDK where it prompts you
for permission to send analytics, hanging the build.  If you don't
want to send build info to Pebble, you can change the filename to
NO_TRACKING in your local version.
