### PR TITLE
Fix syntax error, remove toolchain install

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-// Install NPM 3
+# Install NPM 3
 npm install npm@3 -g
 
 set -e
@@ -15,12 +15,9 @@ touch ~/.pebble-sdk/ENABLE_ANALYTICS
 # Get the Pebble SDK and toolchain
 if [ ! -d $HOME/pebble-dev/${PEBBLE_SDK} ]; then
   wget https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/${PEBBLE_SDK}.tar.bz2
-  wget http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk/arm-cs-tools-ubuntu-universal.tar.gz
 
   # Extract the SDK
   tar -jxf ${PEBBLE_SDK}.tar.bz2 -C ~/pebble-dev/
-  # Extract the toolchain
-  tar zxf arm-cs-tools-ubuntu-universal.tar.gz -C ~/pebble-dev/${PEBBLE_SDK}
 
   # Install the Python library dependencies locally
   cd ~/pebble-dev/${PEBBLE_SDK}


### PR DESCRIPTION
The toolchain is part of the modern pebble SDK tarball, so it doesn't need to be downloaded separately
